### PR TITLE
[feature] put range to selection with checkbox

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -72,6 +72,10 @@ div.load_save_modal {
     width: 500px;
 }
 
+.range_checkbox {
+    margin-right: 10px;
+}
+
 
 /*************************** Dead Cards *******************************/
 
@@ -119,8 +123,3 @@ div.selected-suit {
 .btn-persist {
     width: 150px;
 }
-
-.hidden {
-    display: none;
-}
-

--- a/index.phtml
+++ b/index.phtml
@@ -1,11 +1,19 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-16976673-5"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-16976673-5');
+    </script>
     <!-- Required meta tags -->
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta http-equiv="cache-control" content="no-cache" />
-
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
     <link rel="stylesheet" href="css/index.css">
@@ -51,12 +59,12 @@
 
             <table class="table legend-table">
               <tr>
-                <td><button type="button" class="btn" style="background-color: #7f7f7b"></button> = FOLD or CHECK <span class="stat fold-stat"></span></td>
-                <td><button type="button" class="btn" style="background-color: #238a0a"></button> = CALL <span class="stat call-stat"></span></td>
+                <td><input type="checkbox" class="range_checkbox" data-range="fold"><button type="button" class="btn" style="background-color: #7f7f7b"></button> = FOLD or CHECK <span class="stat fold-stat"></span></td>
+                <td><input type="checkbox" class="range_checkbox" data-range="call"><button type="button" class="btn" style="background-color: #238a0a"></button> = CALL <span class="stat call-stat"></span></td>
               </tr>
               <tr>
-                <td><button type="button" class="btn" style="background-color: #f94f58"></button> = BLUFF <span class="stat bluff-stat"></span></td>
-                <td><button type="button" class="btn" style="background-color: #c11111"></button> = VALUE BET / RAISE <span class="stat raise-stat"></span></td>
+                <td><input type="checkbox" class="range_checkbox" data-range="bluff"><button type="button" class="btn" style="background-color: #f94f58"></button> = BLUFF <span class="stat bluff-stat"></span></td>
+                <td><input type="checkbox" class="range_checkbox" data-range="raise"><button type="button" class="btn" style="background-color: #c11111"></button> = VALUE BET / RAISE <span class="stat raise-stat"></span></td>
               </tr>
             </table>
 

--- a/js/index.js
+++ b/js/index.js
@@ -79,6 +79,38 @@ function update_stats() {
   $raise.text(sprintf("%d(%.1f%%)", g_raise_combos.size,  100.0 * g_raise_combos.size / total_comobs));
 }
 
+function range_to_selection() {
+  var range = $(this).data('range');
+  var cur_range = null;
+  if (range == 'fold') {
+    cur_range = g_fold_range;
+  } else if (range == 'call') {
+    cur_range = g_call_range;
+  } else if (range == 'bluff') {
+    cur_range = g_bluff_range;
+  } else if (range == 'raise') {
+    cur_range = g_raise_range;
+  } else {
+    alert('unknown range: ' + range);
+  }
+
+  if ($(this).is(":checked")) {
+    g_selected_hands = new Set([...g_selected_hands, ...cur_range]);
+    for (var hand of g_selected_hands) {
+      var $td = g_hand_to_td[hand];
+      $td.addClass('selected-hand');
+    }
+  } else {
+    g_selected_hands = new Set([...g_selected_hands].filter(x => !cur_range.has(x)));
+    for (var hand of cur_range) {
+      var $td = g_hand_to_td[hand];
+      $td.removeClass('selected-hand');
+    }
+  }
+
+  update_combos(g_selected_hands, g_selected_combos);
+}
+
 /**************************** Driver ******************************/
 
 $(function() {
@@ -116,6 +148,7 @@ $(function() {
   $("#btn_save_tree").click(add_range);
   $("#btn_load_range").click(load_range);
   $("#reset_selection_button").click(clear_selected_hands);
+  $("input.range_checkbox").click(range_to_selection);
   load_treeview();
 
   // bind persistent events


### PR DESCRIPTION
Add checkboxes next to the range statistics. By selecting/unselecting them, the corresponding range with be added to or removed from selection. This is useful for carrying ranges from one street to next.